### PR TITLE
Irida next chown

### DIFF
--- a/README.irida-next.md
+++ b/README.irida-next.md
@@ -3,8 +3,8 @@
 To start the IRIDA Next environment, follow these steps:
 
 ```bash
-$ IRIDA_NEXT_PATH=/PATH/TO/IRIDA/NEXT/REPO docker compose -f compose.irida-next.yml up -d --build
-$ IRIDA_NEXT_PATH=/PATH/TO/IRIDA/NEXT/REPO docker compose -f compose.irida-next.yml exec app bash
+$ IRIDA_NEXT_PATH=/PATH/TO/IRIDA/NEXT/REPO MYUID="$(id -u)" MYGID="$(id -g)" docker compose -f compose.irida-next.yml up -d --build
+$ IRIDA_NEXT_PATH=/PATH/TO/IRIDA/NEXT/REPO MYUID="$(id -u)" MYGID="$(id -g)" docker compose -f compose.irida-next.yml exec app bash
 # inside container
 $ sapporo
 ```

--- a/compose.irida-next.yml
+++ b/compose.irida-next.yml
@@ -20,6 +20,8 @@ services:
       - SAPPORO_PORT=1122
       - SAPPORO_DEBUG=True
       - SAPPORO_RUN_DIR=${PWD}/run
+      - MYUID=${MYUID}
+      - MYGID=${MYGID}
       # - SAPPORO_DATA_REMOVE_OLDER_THAN_DAYS=30
       # - SAPPORO_GET_RUNS=True
       # - SAPPORO_RUN_ONLY_REGISTERED_WORKFLOWS=False

--- a/sapporo/run.sh
+++ b/sapporo/run.sh
@@ -18,7 +18,6 @@ function run_wf() {
   upload
   date +"%Y-%m-%dT%H:%M:%S" >${end_time}
   echo 0 >${exit_code}
-  chown_outputs
   echo "COMPLETE" >${state}
   clean_rundir &
   exit 0
@@ -36,6 +35,7 @@ function run_nextflow() {
   find ${exe_dir} -type f -exec chmod 777 {} \;
   echo ${cmd_txt} >${cmd}
   eval ${cmd_txt} || executor_error
+  chown_outputs
 }
 
 function run_toil() {

--- a/sapporo/run.sh
+++ b/sapporo/run.sh
@@ -18,6 +18,7 @@ function run_wf() {
   upload
   date +"%Y-%m-%dT%H:%M:%S" >${end_time}
   echo 0 >${exit_code}
+  chown_outputs
   echo "COMPLETE" >${state}
   clean_rundir &
   exit 0
@@ -146,6 +147,12 @@ function generate_outputs_list() {
 
 function generate_ro_crate() {
   python3 -c "from sapporo.ro_crate import generate_ro_crate; generate_ro_crate('${run_dir}')" || echo "{}" >"${run_dir}/ro-crate-metadata.json" || true
+}
+
+function chown_outputs() {
+  #MYOUTDIR=$(python3 -c "import json; print(json.load('${wf_params}'['outdir'])")
+  MYOUTDIR=$(python3 -c "import json; print(json.load(open('${wf_params}'))['outdir'])")
+  chown -R ${MYUID}:${MYGID} ${MYOUTDIR}
 }
 
 function upload() {


### PR DESCRIPTION
UID and GID are passed into the docker container and as env vars. Then when a nextflow run finishes the UID/GID are used to chown the output files, allowing IRIDA Next to remove them.