### PR TITLE
Mount tmp dir to support irida integration tests

### DIFF
--- a/compose.irida-next.yml
+++ b/compose.irida-next.yml
@@ -10,6 +10,7 @@ services:
       - ${PWD}/sapporo:/app/sapporo
       - ${PWD}/tests:/app/tests
       - ${IRIDA_NEXT_PATH}/storage:${IRIDA_NEXT_PATH}/storage
+      - ${IRIDA_NEXT_PATH}/tmp/storage:${IRIDA_NEXT_PATH}/tmp/storage
       # The ones below are mounted for cwltool and DinD.
       - ${PWD}/run:${PWD}/run
       - /var/run/docker.sock:/var/run/docker.sock

--- a/compose.irida-next.yml
+++ b/compose.irida-next.yml
@@ -10,7 +10,7 @@ services:
       - ${PWD}/sapporo:/app/sapporo
       - ${PWD}/tests:/app/tests
       - ${IRIDA_NEXT_PATH}/storage:${IRIDA_NEXT_PATH}/storage
-      - ${IRIDA_NEXT_PATH}/tmp/storage:${IRIDA_NEXT_PATH}/tmp/storage
+      - ${IRIDA_NEXT_PATH}/tmp:${IRIDA_NEXT_PATH}/tmp
       # The ones below are mounted for cwltool and DinD.
       - ${PWD}/run:${PWD}/run
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Mounts the IRIDA Next tmp/ dir so IRIDA Next sapporo integration tests can be run locally